### PR TITLE
chore: Fix codegen for fork

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -223,13 +223,7 @@ jobs:
         run: |
           mkdir -p /home/runner/go/src/github.com/argoproj
           ln -s "$PWD" /home/runner/go/src/github.com/argoproj/argo-workflows
-      - run: |
-          pwd
-          ls -lrth
-          echo "---"
-          ls -lrth /home/runner/go/src/github.com/argoproj/argo-workflows
-          cd /home/runner/go/src/github.com/argoproj/argo-workflows
-          make codegen -B STATIC_FILES=false
+      - run: make codegen -B STATIC_FILES=false
       - run: git diff --exit-code
 
   lint:

--- a/Makefile
+++ b/Makefile
@@ -95,13 +95,13 @@ $(info KUBECTX=$(KUBECTX) DOCKER_DESKTOP=$(DOCKER_DESKTOP) K3D=$(K3D) DOCKER_PUS
 $(info RUN_MODE=$(RUN_MODE) PROFILE=$(PROFILE) AUTH_MODE=$(AUTH_MODE) SECURE=$(SECURE) STATIC_FILES=$(STATIC_FILES) ALWAYS_OFFLOAD_NODE_STATUS=$(ALWAYS_OFFLOAD_NODE_STATUS) UPPERIO_DB_DEBUG=$(UPPERIO_DB_DEBUG) LOG_LEVEL=$(LOG_LEVEL) NAMESPACED=$(NAMESPACED))
 
 override LDFLAGS += \
-  -X github.com/pipekit/argo-workflows/v3.version=$(VERSION) \
-  -X github.com/pipekit/argo-workflows/v3.buildDate=${BUILD_DATE} \
-  -X github.com/pipekit/argo-workflows/v3.gitCommit=${GIT_COMMIT} \
-  -X github.com/pipekit/argo-workflows/v3.gitTreeState=${GIT_TREE_STATE}
+  -X github.com/argoproj/argo-workflows/v3.version=$(VERSION) \
+  -X github.com/argoproj/argo-workflows/v3.buildDate=${BUILD_DATE} \
+  -X github.com/argoproj/argo-workflows/v3.gitCommit=${GIT_COMMIT} \
+  -X github.com/argoproj/argo-workflows/v3.gitTreeState=${GIT_TREE_STATE}
 
 ifneq ($(GIT_TAG),)
-override LDFLAGS += -X github.com/pipekit/argo-workflows/v3.gitTag=${GIT_TAG}
+override LDFLAGS += -X github.com/argoproj/argo-workflows/v3.gitTag=${GIT_TAG}
 endif
 
 ifndef $(GOPATH)
@@ -109,9 +109,9 @@ ifndef $(GOPATH)
 	export GOPATH
 endif
 
-ARGOEXEC_PKGS    := $(shell echo cmd/argoexec            && go list -f '{{ join .Deps "\n" }}' ./cmd/argoexec/            | grep 'pipekit/argo-workflows/v3/' | cut -c 39-)
-CLI_PKGS         := $(shell echo cmd/argo                && go list -f '{{ join .Deps "\n" }}' ./cmd/argo/                | grep 'pipekit/argo-workflows/v3/' | cut -c 39-)
-CONTROLLER_PKGS  := $(shell echo cmd/workflow-controller && go list -f '{{ join .Deps "\n" }}' ./cmd/workflow-controller/ | grep 'pipekit/argo-workflows/v3/' | cut -c 39-)
+ARGOEXEC_PKGS    := $(shell echo cmd/argoexec            && go list -f '{{ join .Deps "\n" }}' ./cmd/argoexec/            | grep 'argoproj/argo-workflows/v3/' | cut -c 39-)
+CLI_PKGS         := $(shell echo cmd/argo                && go list -f '{{ join .Deps "\n" }}' ./cmd/argo/                | grep 'argoproj/argo-workflows/v3/' | cut -c 39-)
+CONTROLLER_PKGS  := $(shell echo cmd/workflow-controller && go list -f '{{ join .Deps "\n" }}' ./cmd/workflow-controller/ | grep 'argoproj/argo-workflows/v3/' | cut -c 39-)
 TYPES := $(shell find pkg/apis/workflow/v1alpha1 -type f -name '*.go' -not -name openapi_generated.go -not -name '*generated*' -not -name '*test.go')
 CRDS := $(shell find manifests/base/crds -type f -name 'argoproj.io_*.yaml')
 SWAGGER_FILES := pkg/apiclient/_.primary.swagger.json \
@@ -142,7 +142,7 @@ define protoc
       --grpc-gateway_out=logtostderr=true:$(GOPATH)/src \
       --swagger_out=logtostderr=true,fqn_for_swagger_name=true:. \
       $(1)
-     perl -i -pe 's|pipekit/argo-workflows/|pipekit/argo-workflows/v3/|g' `echo "$(1)" | sed 's/proto/pb.go/g'`
+     perl -i -pe 's|argoproj/argo-workflows/|argoproj/argo-workflows/v3/|g' `echo "$(1)" | sed 's/proto/pb.go/g'`
 
 endef
 
@@ -545,8 +545,8 @@ pkg/apis/workflow/v1alpha1/openapi_generated.go: $(GOPATH)/bin/openapi-gen $(TYP
 	[ -e ./v3 ] || ln -s . v3
 	$(GOPATH)/bin/openapi-gen \
 	  --go-header-file ./hack/custom-boilerplate.go.txt \
-	  --input-dirs github.com/pipekit/argo-workflows/v3/pkg/apis/workflow/v1alpha1 \
-	  --output-package github.com/pipekit/argo-workflows/v3/pkg/apis/workflow/v1alpha1 \
+	  --input-dirs github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1 \
+	  --output-package github.com/argoproj/argo-workflows/v3/pkg/apis/workflow/v1alpha1 \
 	  --report-filename pkg/apis/api-rules/violation_exceptions.list
 	# Delete the link
 	[ -e ./v3 ] && rm -rf v3
@@ -558,7 +558,7 @@ pkg/apis/workflow/v1alpha1/zz_generated.deepcopy.go: $(TYPES)
 	[ -e ./v3 ] || ln -s . v3
 	bash $(GOPATH)/pkg/mod/k8s.io/code-generator@v0.21.5/generate-groups.sh \
 	    "deepcopy,client,informer,lister" \
-	    github.com/pipekit/argo-workflows/v3/pkg/client github.com/pipekit/argo-workflows/v3/pkg/apis \
+	    github.com/argoproj/argo-workflows/v3/pkg/client github.com/argoproj/argo-workflows/v3/pkg/apis \
 	    workflow:v1alpha1 \
 	    --go-header-file ./hack/custom-boilerplate.go.txt
 	# Delete the link


### PR DESCRIPTION
This PR:
- Fixes the codegen panic. It wants the packages to be called argoproj instead of pipekit. We'd have to scrub all instances of argoproj, which we don't want to do