### PR TITLE
fix: ensure node name is defined when executing container. Quickfix for LadyBug. 

### DIFF
--- a/workflow/controller/operator.go
+++ b/workflow/controller/operator.go
@@ -2531,6 +2531,11 @@ func (woc *wfOperationCtx) executeContainer(ctx context.Context, nodeName string
 	node := woc.wf.GetNodeByName(nodeName)
 	if node == nil {
 		node = woc.initializeExecutableNode(nodeName, wfv1.NodeTypePod, templateScope, tmpl, orgTmpl, opts.boundaryID, wfv1.NodePending)
+	} else {
+		// TODO: Address dirty fix later, pushed for LadyBug
+		if strings.TrimSpace(node.Name) == "" {
+			node.Name = nodeName
+		}
 	}
 
 	// Check if the output of this container is referenced elsewhere in the Workflow. If so, make sure to include it during


### PR DESCRIPTION
Need to properly fix this later, looks to be some kinda race condition where sometimes Name is defined and sometimes it is not. 