### PR TITLE
chore: codegen should run after unit tests pass

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -196,7 +196,7 @@ jobs:
   codegen:
     name: Codegen
     runs-on: ubuntu-latest
-    # needs: [ tests ]
+    needs: [ tests ]
     timeout-minutes: 20
     env:
       GOPATH: /home/runner/go


### PR DESCRIPTION
Fix a debug step that was put in when fixing codegen that wasn't then reverted.
