### PR TITLE
chore: correct container name in release process

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -250,8 +250,8 @@ jobs:
             if [ $target = "argoexec" ]; then
               # docker manifest create $image_name ${image_name}-linux-arm64 ${image_name}-linux-amd64 ${image_name}-windows
               # docker manifest create quay.io/$image_name quay.io/${image_name}-linux-arm64 quay.io/${image_name}-linux-amd64 quay.io/${image_name}-windows
-              docker manifest create $image_name ${image_name}-linux-amd64 ${image_name}-build-linux-arm64
-              docker manifest create quay.io/$image_name quay.io/${image_name}-linux-amd64 quay.io/${image_name}-build-linux-arm64
+              docker manifest create $image_name ${image_name}-linux-amd64 ${image_name}-linux-arm64
+              docker manifest create quay.io/$image_name quay.io/${image_name}-linux-amd64 quay.io/${image_name}-linux-arm64
             else
               docker manifest create $image_name ${image_name}-linux-arm64 ${image_name}-linux-amd64
               docker manifest create quay.io/$image_name quay.io/${image_name}-linux-arm64 quay.io/${image_name}-linux-amd64


### PR DESCRIPTION
This typo blocks the release.

![image](https://user-images.githubusercontent.com/45351296/227135267-53633f52-4633-4da1-8ba3-e96fd719b944.png)

![image](https://user-images.githubusercontent.com/45351296/227135322-de9558a9-7867-48ef-a3ec-27ca0779103e.png)

